### PR TITLE
add Mato::Docuent#apply_html_filters to modify documents safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ Rails.fetch(digest(markdown_content)) do
   mato.process(markdown_content)
 end
 
+
+# applies extra filters and returns a new Mato::Document
+# because Mato::Document is serializable, you can cache the base doc and then apply extra filters on demaond
+new_doc = doc.apply_html_filters(
+  -> (fragment) { modify_fragment!(fragment) },
+  SomeHtmlFilter.new, # anything that has #call(node) method
+)
 ```
 
 ## Installation

--- a/lib/mato/document.rb
+++ b/lib/mato/document.rb
@@ -15,6 +15,15 @@ module Mato
       @fragment = fragment
     end
 
+    # @return [Nokogiri::XML::Node] A copy of fragment that are modified by html_filters
+    def apply_html_filters(*html_filters)
+      new_fragment = fragment.dup
+      html_filters.each do |html_filter|
+        html_filter.call(new_fragment)
+      end
+      self.class.new(new_fragment.freeze)
+    end
+
     # @param [String] selector
     # @return [Nokogiri::XML::NodeSet]
     def css(selector)
@@ -46,7 +55,7 @@ module Mato
     end
 
     def marshal_load(data)
-      initialize(Nokogiri::HTML.fragment(data[:fragment]))
+      initialize(Nokogiri::HTML.fragment(data[:fragment]).freeze)
     end
   end
 end

--- a/lib/mato/processor.rb
+++ b/lib/mato/processor.rb
@@ -38,7 +38,7 @@ module Mato
         filter.call(html_node, context)
       end
 
-      config.document_factory.new(html_node)
+      config.document_factory.new(html_node.freeze)
     end
 
     # @param [String] text

--- a/test/mato_test.rb
+++ b/test/mato_test.rb
@@ -3,23 +3,37 @@
 require_relative './test_helper'
 
 class MatoTest < Minitest::Test
+  def mato
+    @mato ||= Mato.define do |_config|
+    end
+  end
+
   def test_that_it_has_a_version_number
     refute_nil ::Mato::VERSION
   end
 
   def test_it_does_something_useful
-    mato = Mato.define do |_config|
+    assert do
+      mato.process('Hello, world!').render_html == "<p>Hello, world!</p>\n"
     end
-
-    assert { mato.process('Hello, world!').render_html == "<p>Hello, world!</p>\n" }
   end
 
   def test_document_is_serializable
-    mato = Mato.define do |_config|
+    assert do
+      Marshal.load(Marshal.dump(mato.process('Hello, world!'))).render_html == "<p>Hello, world!</p>\n"
+    end
+  end
+
+  def test_apply_html_filters
+    doc = mato.process('Hello, world!')
+    new_doc = doc.apply_html_filters(->(node) { node.child.replace("<p>Hi!</p>") })
+
+    assert do
+      doc.render_html == "<p>Hello, world!</p>\n"
     end
 
     assert do
-      Marshal.load(Marshal.dump(mato.process('Hello, world!'))).render_html == "<p>Hello, world!</p>\n"
+      new_doc.render_html == "<p>Hi!</p>\n"
     end
   end
 end


### PR DESCRIPTION
This is useful when there are extra HTML filters that depend on the request context.

For example, ACL and context-aware HTML tag filters.