### PR TITLE
Wraps single, bare `<img/>` with `<p/>`

### DIFF
--- a/lib/mato.rb
+++ b/lib/mato.rb
@@ -12,6 +12,7 @@ require_relative "./mato/html_filters/syntax_highlight"
 require_relative "./mato/html_filters/task_list"
 require_relative "./mato/html_filters/section_anchor"
 require_relative "./mato/html_filters/sanitization"
+require_relative "./mato/html_filters/bare_inline_element"
 
 module Mato
   # @param [Proc] block

--- a/lib/mato/html_filters/bare_inline_element.rb
+++ b/lib/mato/html_filters/bare_inline_element.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Wraps CommonMark's HTML blocks with <p/>.
+#
+# See Also:
+# http://spec.commonmark.org/0.28/#html-blocks
+# https://github.com/commonmark/CommonMark/issues/492
+module Mato
+  module HtmlFilters
+    class BareInlineElement
+      STANDALONE_ININE_ELEMENTS = Set.new([
+        "img",
+        "input",
+        "textarea",
+      ])
+
+      def call(doc)
+        doc.children.each do |node|
+          if STANDALONE_ININE_ELEMENTS.include?(node.name)
+            parent = Nokogiri::HTML.fragment('<p/>')
+            parent.child.add_child(node.dup)
+            node.replace(parent)
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/html_filters/bare_inline_element_test.rb
+++ b/test/html_filters/bare_inline_element_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+require 'sanitize'
+
+class BareInlineElementTest < FilterTest
+
+  def subject
+    Mato::HtmlFilters::BareInlineElement.new
+  end
+
+  def test_mention_filter_to_work
+    source = '<img src="foo.png">'
+    assert_html_eq(process(source).render_html, %{<p>#{source}</p>\n})
+  end
+end


### PR DESCRIPTION
This is because CommonMark handles a single HTML tag as "HTML blocks",
which are not wrapped with <p/>. Bare inline elements, such as <img/>
should be wrapped with <p/> even if it's a single HTML tag.

The BareInlineElement fixes this CommonMark's spec to make the behavior
as expectable.

see also:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Inline_elements
* http://spec.commonmark.org/0.28/#html-blocks
* https://github.com/commonmark/CommonMark/issues/492
