### PR TITLE
add Mato::Converter to convert Redcarpet markdown to CommonMark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rouge", ">= 2.0"
 gem "sanitize", ">= 3.0"
 
 gem "bundler", ">= 1.14"
-gem "rake", ">= 10.0"
 gem "m"
 gem "minitest"
 gem "minitest-power_assert"
+gem "rake", ">= 10.0"

--- a/lib/mato.rb
+++ b/lib/mato.rb
@@ -4,6 +4,7 @@
 require_relative "./mato/version"
 require_relative "./mato/config"
 require_relative "./mato/processor"
+require_relative "./mato/converter"
 
 # filter classes
 require_relative "./mato/html_filters/token_link"

--- a/lib/mato/converter.rb
+++ b/lib/mato/converter.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'set'
+
+# Convert X-flavored markdown to CommonMark
+module Mato
+  class Converter
+
+    FLAVORES = Set.new([
+                         :redcarpet, # legacy GFM uses it
+                       ]).freeze
+
+    attr_reader :processor
+    attr_reader :content
+    attr_reader :flavor
+
+    # @return [Array<String>]
+    attr_reader :content_lines
+
+    def initialize(processor, content, flavor)
+      unless FLAVORES.include?(flavor)
+        raise "Unsupported flavor #{flavor.inspect}, it must be one of: #{FLAVORES.map(&:inspect).join(' ')}"
+      end
+
+      @processor = processor
+      @content = content
+      @content_lines = content.split(/\n/)
+      @flavor = flavor
+    end
+
+    def run
+      # @type [CommonMarker::Node]
+      document = processor.parse_markdown(content)
+
+      convert_headings!(document)
+
+      content_lines.join("\n").tap do |c|
+        # fixup newlines removed by String#split
+        content.scan(/\n+\z/) do |matched|
+          c << matched
+        end
+      end
+    end
+
+    def convert_headings!(document)
+      document.walk.select do |node|
+        node.type == :text &&
+          node.sourcepos[:start_column] == 1 &&
+          node.parent.type == :paragraph &&
+          node.parent.parent.type == :document
+      end.reverse.each do |node|
+        replacement = node.string_content.gsub(/\A(#+)(?=\S)/, '\1 ')
+
+        if node.string_content != replacement
+          pos = node.sourcepos
+          content_lines[pos[:start_line] - 1][(pos[:start_column] - 1)...pos[:end_column]] = replacement
+        end
+      end
+    end
+  end
+end

--- a/lib/mato/html_filters/bare_inline_element.rb
+++ b/lib/mato/html_filters/bare_inline_element.rb
@@ -9,18 +9,17 @@ module Mato
   module HtmlFilters
     class BareInlineElement
       STANDALONE_INLINE_ELEMENTS = Set.new([
-        "img",
-        "input",
-        "textarea",
-      ])
+                                             "img",
+                                             "input",
+                                             "textarea",
+                                           ])
 
       def call(doc)
         doc.children.each do |node|
-          if STANDALONE_INLINE_ELEMENTS.include?(node.name)
-            parent = Nokogiri::HTML.fragment('<p/>')
-            parent.child.add_child(node.dup)
-            node.replace(parent)
-          end
+          next unless STANDALONE_INLINE_ELEMENTS.include?(node.name)
+          parent = Nokogiri::HTML.fragment('<p/>')
+          parent.child.add_child(node.dup)
+          node.replace(parent)
         end
       end
     end

--- a/lib/mato/processor.rb
+++ b/lib/mato/processor.rb
@@ -59,5 +59,9 @@ module Mato
     def parse_html(html)
       config.html_parser.parse(html)
     end
+
+    def convert(content, flavor:)
+      Mato::Converter.new(self, content, flavor).run
+    end
   end
 end

--- a/test/mato_converter_test.rb
+++ b/test/mato_converter_test.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require_relative './test_helper'
+
+class MatoConverterTest < MyTest
+  def mato
+    @mato ||= Mato.define do |_config|
+    end
+  end
+
+  def patterns # rubocop:disable Metrics/MethodLength
+    [
+      ['#Hello, world!', '# Hello, world!'],
+      ['##Hello, world!', '## Hello, world!'],
+      ["##Hello, world!\n\n", "## Hello, world!\n\n"],
+      ['> #Hello, world!', '> #Hello, world!'],
+      [
+        <<~'MD',
+          ```
+          #foo
+          ```
+          #bar
+            MD
+
+        <<~'MD',
+          ```
+          #foo
+          ```
+          # bar
+            MD
+      ],
+      [
+        <<~'MD',
+          * #foo
+           * #bar
+            MD
+
+        <<~'MD',
+          * #foo
+           * #bar
+            MD
+      ],
+      [
+        <<~'MD',
+          <p>#foo</p>
+          MD
+
+        <<~'MD',
+          <p>#foo</p>
+          MD
+      ],
+      [
+        <<~'MD',
+          #foo
+          ##bar
+          #baz
+          yey!
+            MD
+
+        <<~'MD',
+          # foo
+          ## bar
+          # baz
+          yey!
+            MD
+      ],
+      [
+        <<-'MD', # keep indent in contents
+              #foo
+              ##bar
+              #baz
+              yey!
+            MD
+
+        <<-'MD', # keep indent in contents
+              #foo
+              ##bar
+              #baz
+              yey!
+            MD
+      ],
+      [
+        <<~'MD',
+          #foo *#bar* #baz
+          MD
+
+        <<~'MD',
+          # foo *#bar* #baz
+          MD
+      ],
+    ]
+  end
+
+  def test_convert
+    patterns.each do |input, output|
+      assert { mato.convert(input, flavor: :redcarpet) == output }
+    end
+  end
+end


### PR DESCRIPTION
Redcarpet-style の `#heading` を CommonMark-style の `# heading` に変換します。構文を理解したうえで変換するので、たとえば fenced code blocksの中身は扱いません。

詳細は  `test/mato_converter_test.rb` を参照してください。