### PR TITLE
Add UNSAFE to DEFAULT_MARKDOWN_RENDER_OPTIONS

### DIFF
--- a/lib/mato/config.rb
+++ b/lib/mato/config.rb
@@ -18,6 +18,7 @@ module Mato
       :DEFAULT,
       :HARDBREAKS, # convert "\n" as <br/>
       :TABLE_PREFER_STYLE_ATTRIBUTES,
+      :UNSAFE,
       # :SOURCEPOS, // TODO: enable it after assertions are supported
     ].freeze
 

--- a/mato.gemspec
+++ b/mato.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.3"
 
-  spec.add_runtime_dependency "commonmarker", ">= 0.17.8"
+  spec.add_runtime_dependency "commonmarker", ">= 0.18.1"
   spec.add_runtime_dependency "nokogiri", ">= 1.6"
   spec.add_runtime_dependency "rouge", ">= 3.0.0"
 end

--- a/test/mato_test.rb
+++ b/test/mato_test.rb
@@ -54,7 +54,7 @@ class MatoTest < MyTest
 
     assert do
       doc.render_html == <<~'HTML'
-        <p>This is some text.<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup>. Other text.[^footnote].</p>
+        <p>This is some text.<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.[^footnote].</p>
         <section class="footnotes">
         <ol>
         <li id="fn1">


### PR DESCRIPTION
The behavior of html tag render has changed in commonmarker v0.18.1.
https://github.com/gjtorikian/commonmarker/compare/v0.17.13...v0.18.1#diff-04c6e90faac2675aa89e2176d2eec7d8R149

In order to keep the previous behavior, UNSAFE parameter is necessary, so I will add it.