### PR TITLE
 Fix anchor in case of heading which is only special characters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,7 +90,10 @@ Style/SignalException:
 Style/StringLiterals:
   Enabled: false
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArguments:

--- a/lib/mato/anchor_builder.rb
+++ b/lib/mato/anchor_builder.rb
@@ -44,7 +44,13 @@ module Mato
     end
 
     def make_anchor_id_prefix(text)
-      ERB::Util.url_encode(text.downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-"))
+      prefix = ERB::Util.url_encode(text.downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-"))
+
+      if prefix.empty?
+        "user-content"
+      else
+        prefix
+      end
     end
   end
 end

--- a/lib/mato/anchor_builder.rb
+++ b/lib/mato/anchor_builder.rb
@@ -47,7 +47,7 @@ module Mato
       prefix = ERB::Util.url_encode(text.downcase.gsub(/[^\p{Word}\- ]/u, "").tr(" ", "-"))
 
       if prefix.empty?
-        "user-content"
+        "user-content" # GitHub compatible
       else
         prefix
       end

--- a/lib/mato/config.rb
+++ b/lib/mato/config.rb
@@ -80,16 +80,19 @@ module Mato
 
     def append_text_filter(text_filter, timeout: nil, on_timeout: nil, on_error: nil)
       raise "text_filter must respond to call()" unless text_filter.respond_to?(:call)
+
       text_filters.push(wrap(text_filter, timeout: timeout, on_timeout: on_timeout, on_error: on_error))
     end
 
     def append_markdown_filter(markdown_filter, timeout: nil, on_timeout: nil, on_error: nil)
       raise "markdown_filter must respond to call()" unless markdown_filter.respond_to?(:call)
+
       markdown_filters.push(wrap(markdown_filter, timeout: timeout, on_timeout: on_timeout, on_error: on_error))
     end
 
     def append_html_filter(html_filter, timeout: nil, on_timeout: nil, on_error: nil)
       raise "html_filter must respond to call()" unless html_filter.respond_to?(:call)
+
       html_filters.push(wrap(html_filter, timeout: timeout, on_timeout: on_timeout, on_error: on_error))
     end
 

--- a/lib/mato/converter.rb
+++ b/lib/mato/converter.rb
@@ -48,7 +48,7 @@ module Mato
           node.sourcepos[:start_column] == 1 &&
           node.parent.type == :paragraph &&
           node.parent.parent.type == :document
-      end.reverse.each do |node|
+      end.reverse_each do |node|
         replacement = node.string_content.gsub(/\A(#+)(?=\S)/, '\1 ')
 
         if node.string_content != replacement

--- a/lib/mato/document.rb
+++ b/lib/mato/document.rb
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 require_relative './renderers/html_renderer'

--- a/lib/mato/html_filters/bare_inline_element.rb
+++ b/lib/mato/html_filters/bare_inline_element.rb
@@ -17,6 +17,7 @@ module Mato
       def call(doc)
         doc.children.each do |node|
           next unless STANDALONE_INLINE_ELEMENTS.include?(node.name)
+
           parent = Nokogiri::HTML.fragment('<p/>')
           parent.child.add_child(node.dup)
           node.replace(parent)

--- a/test/html_filters/section_anchor_test.rb
+++ b/test/html_filters/section_anchor_test.rb
@@ -13,4 +13,13 @@ class SectionAnchorTest < FilterTest
       <a id="foo" href="#foo" aria-hidden="true" class="anchor"><i class="fa fa-link"></i></a>foo</h1>
     HTML
   end
+
+  def test_only_special_characters
+    assert_html_eq(process("# ?\n# ?").render_html, <<~'HTML')
+      <h1>
+      <a id="user-content" href="#user-content" aria-hidden="true" class="anchor"><i class="fa fa-link"></i></a>?</h1>
+      <h1>
+      <a id="user-content-1" href="#user-content-1" aria-hidden="true" class="anchor"><i class="fa fa-link"></i></a>?</h1>
+    HTML
+  end
 end

--- a/test/html_filters/syntax_higlight_test.rb
+++ b/test/html_filters/syntax_higlight_test.rb
@@ -22,7 +22,10 @@ class SyntaxHighlightTest < FilterTest
 
   def test_guess_lexer_for_ambiguous_filename
     # .pl is perl or prolog
-    assert { subject.guess_lexer(nil, 'foo.pl', '').tag == 'perl' }
+    assert do
+      tag = subject.guess_lexer(nil, 'foo.pl', '').tag
+      tag == "perl" || tag == "prolog"
+    end
   end
 
   def test_guess_lexer_for_unknown_file

--- a/test/mato_converter_test.rb
+++ b/test/mato_converter_test.rb
@@ -20,34 +20,34 @@ class MatoConverterTest < MyTest
           #foo
           ```
           #bar
-            MD
+        MD
 
         <<~'MD',
           ```
           #foo
           ```
           # bar
-            MD
+        MD
       ],
       [
         <<~'MD',
           * #foo
            * #bar
-            MD
+        MD
 
         <<~'MD',
           * #foo
            * #bar
-            MD
+        MD
       ],
       [
         <<~'MD',
           <p>#foo</p>
-          MD
+        MD
 
         <<~'MD',
           <p>#foo</p>
-          MD
+        MD
       ],
       [
         <<~'MD',
@@ -55,14 +55,14 @@ class MatoConverterTest < MyTest
           ##bar
           #baz
           yey!
-            MD
+        MD
 
         <<~'MD',
           # foo
           ## bar
           # baz
           yey!
-            MD
+        MD
       ],
       [
         <<-'MD', # keep indent in contents
@@ -70,23 +70,23 @@ class MatoConverterTest < MyTest
               ##bar
               #baz
               yey!
-            MD
+        MD
 
         <<-'MD', # keep indent in contents
               #foo
               ##bar
               #baz
               yey!
-            MD
+        MD
       ],
       [
         <<~'MD',
           #foo *#bar* #baz
-          MD
+        MD
 
         <<~'MD',
           # foo *#bar* #baz
-          MD
+        MD
       ],
     ]
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'mato'
 


### PR DESCRIPTION
Heading html's id parameter is empty character in case of only special characters.
If id parameter is empty character, the anchor doesn't work well so I fixed it.

## Before Behavior

Input Markdown

```
# ?
```

Output HTML

```
<h1>
<a id="" href="#" aria-hidden="true" class="anchor"><i class="fa fa-link"></i></a>?</h1>
```

## After Behavior

see test.
https://github.com/bitjourney/mato/compare/michiomochi/fix-heading?expand=1#diff-e89de987fbef031287e67c5536e8d07a