### PR TITLE
Add test matrix for new Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 rvm:
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
   - ruby-head
 
 matrix:


### PR DESCRIPTION
Add test matrix for Ruby 2.5 and 2.6.

I guess CI will fail by bundler v2 problem. I'll fix it also after opening this pull request.