### PR TITLE
Refer only element has metion-candidate class in metion link process

### DIFF
--- a/lib/mato/html_filters/mention_link.rb
+++ b/lib/mato/html_filters/mention_link.rb
@@ -52,6 +52,8 @@ module Mato
           # cleanup
           candidates.each do |candidate_fragment|
             candidate_fragment.css('span.mention-candidate').each do |node|
+              next unless node.child
+
               node.replace(node.child.content)
             end
           end

--- a/lib/mato/html_filters/mention_link.rb
+++ b/lib/mato/html_filters/mention_link.rb
@@ -37,7 +37,7 @@ module Mato
           next if text_node.content == candidate_html
 
           candidate_fragment = text_node.replace(candidate_html)
-          candidate_fragment.css('span').each do |mention_element|
+          candidate_fragment.css('span.mention-candidate').each do |mention_element|
             (candidate_map[mention_element.child.content] ||= []) << mention_element
           end
 

--- a/lib/mato/html_filters/mention_link.rb
+++ b/lib/mato/html_filters/mention_link.rb
@@ -38,6 +38,8 @@ module Mato
 
           candidate_fragment = text_node.replace(candidate_html)
           candidate_fragment.css('span.mention-candidate').each do |mention_element|
+            next unless mention_element.child
+
             (candidate_map[mention_element.child.content] ||= []) << mention_element
           end
 

--- a/test/html_filters/mention_link_test.rb
+++ b/test/html_filters/mention_link_test.rb
@@ -56,4 +56,9 @@ class MentionLinkTest < FilterTest
   def test_mention_filter_for_valid_in_pre
     assert_html_eq process('<pre>@valid</pre>').render_html, %{<pre>@valid</pre>\n}
   end
+
+  def test_mention_filder_for_include_escaped_span_class
+    assert_html_eq process('@valid\<span\>\<\/span\>').render_html,
+                   %{<p><a href="https://twitter.com/@valid" class="mention">@valid</a><span></span></p>\n}
+  end
 end

--- a/test/html_filters/mention_link_test.rb
+++ b/test/html_filters/mention_link_test.rb
@@ -61,4 +61,9 @@ class MentionLinkTest < FilterTest
     assert_html_eq process('@valid\<span\>\<\/span\>').render_html,
                    %{<p><a href="https://twitter.com/@valid" class="mention">@valid</a><span></span></p>\n}
   end
+
+  def test_mention_filder_for_include_escaped_span_class_with_mention_candidate_class
+    assert_html_eq process('@valid\<span class="mention-candidate"\>\<\/span\>').render_html,
+                   %{<p><a href="https://twitter.com/@valid" class="mention">@valid</a><span class="mention-candidate"></span></p>\n}
+  end
 end


### PR DESCRIPTION
Error occur in case of included following text in mention link process.

```
@valid\<span\>\<\/span\>
```

Error:

```
NoMethodError: undefined method `content' for nil:NilClass
    /Users/michiomochi/.ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:41:in `block (2 levels) in call'
```