### PR TITLE
CI against Ruby 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 # See also https://github.com/onk/onkcop/blob/master/config/rubocop.yml
+require:
+  - rubocop-performance
 
 AllCops:
   TargetRubyVersion: 2.3
@@ -36,7 +38,7 @@ Metrics/ClassLength:
 Metrics/BlockLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: false
 
 Metrics/MethodLength:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-sudo: false
 language: ruby
 rvm:
-  - 2.3
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
   - ruby-head
 
 matrix:

--- a/Gemfile
+++ b/Gemfile
@@ -12,4 +12,5 @@ gem "m"
 gem "minitest"
 gem "minitest-power_assert"
 gem "rake", ">= 10.0"
-gem "rubocop"
+gem "rubocop", '>= 0.78.0'
+gem 'rubocop-performance'

--- a/sider.yml
+++ b/sider.yml
@@ -1,0 +1,4 @@
+linter:
+  rubocop:
+    gems:
+      - "rubocop-performance"


### PR DESCRIPTION
Note: It removes Ruby 2.3 matrix, because it has been EOL.
I know mato defines the "required ruby version" as ">= 2.3", but we can softly remove the supporting of Ruby 2.3 by removing it from the build matrix.
