### PR TITLE
Display code block as plan text if Rouge raises an error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,10 +3,13 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   DisplayCopNames: true
   Exclude:
     - bin/**/*
+
+Metrics:
+  Enabled: false
 
 Lint/UnusedBlockArgument:
   Enabled: false
@@ -23,31 +26,7 @@ Layout/MultilineMethodCallIndentation:
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-Metrics/AbcSize:
-  Max: 35
-
-Metrics/PerceivedComplexity:
-  Max: 10
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/ClassLength:
-  Enabled: false
-
-Metrics/BlockLength:
-  Enabled: false
-
 Layout/LineLength:
-  Enabled: false
-
-Metrics/MethodLength:
-  Max: 45
-
-Metrics/ModuleLength:
-  Enabled: false
-
-Metrics/ParameterLists:
   Enabled: false
 
 Style/RescueStandardError:
@@ -63,6 +42,12 @@ Style/Documentation:
   Enabled: false
 
 Naming/FileName:
+  Enabled: false
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Naming/RescuedExceptionsVariableName:
   Enabled: false
 
 Style/GuardClause:
@@ -122,6 +107,9 @@ Style/AsciiComments:
 Style/EmptyMethod:
   EnforcedStyle: expanded
 
+Style/RaiseArgs:
+  Enabled: false
+
 Naming/VariableNumber:
   Enabled: false
 
@@ -148,3 +136,20 @@ Style/NonNilCheck:
 
 Performance/RedundantBlockCall:
   Enabled: false
+
+# Configure pending cops
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Style/ExponentialNotation:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -12,5 +12,6 @@ gem "m"
 gem "minitest"
 gem "minitest-power_assert"
 gem "rake", ">= 10.0"
+gem 'rr'
 gem "rubocop", '>= 0.78.0'
 gem 'rubocop-performance'

--- a/lib/mato/html_filters/syntax_highlight.rb
+++ b/lib/mato/html_filters/syntax_highlight.rb
@@ -8,7 +8,7 @@ module Mato
       class RougeError < StandardError
       end
 
-      def initialize(on_rouge_error: -> (ex) { warn ex })
+      def initialize(on_rouge_error: ->(ex) { warn ex })
         @on_rouge_error = on_rouge_error
       end
 

--- a/lib/mato/html_filters/syntax_highlight.rb
+++ b/lib/mato/html_filters/syntax_highlight.rb
@@ -5,6 +5,12 @@
 module Mato
   module HtmlFilters
     class SyntaxHighlight
+      class RougeError < StandardError
+      end
+
+      def initialize(on_rouge_error: -> (ex) { warn ex })
+        @on_rouge_error = on_rouge_error
+      end
 
       # @param [Nokogiri::HTML::DocumentFragment] doc
       def call(doc)
@@ -57,11 +63,21 @@ module Mato
 
         lexer = guess_lexer(language, filename, source)
 
-        document = Nokogiri::HTML.fragment(%{<div class="code-frame"/>})
-
-        div = document.at('div')
-        div.add_child(label_fragment(filename || language || lexer.tag)) if filename || !lexer.is_a?(Rouge::Lexers::PlainText)
-        div.add_child(%{<pre class="highlight"><code data-lang="#{lexer.tag}">#{format(lexer, source)}</code></pre>})
+        begin
+          document = Nokogiri::HTML.fragment(%{<div class="code-frame"/>})
+          div = document.at('div')
+          div.add_child(label_fragment(filename || language || lexer.tag)) if filename || !lexer.is_a?(Rouge::Lexers::PlainText)
+          div.add_child(%{<pre class="highlight"><code data-lang="#{lexer.tag}">#{format(lexer, source)}</code></pre>})
+        rescue => ex
+          if ex.is_a?(RougeError) && !lexer.is_a?(Rouge::Lexers::PlainText)
+            # Retry highlighting with PlainText lexer if Rouge raises an error.
+            # It avoids to affect the error to whole of converting.
+            lexer = Rouge::Lexers::PlainText.new
+            retry
+          else
+            raise ex
+          end
+        end
 
         document
       end
@@ -79,6 +95,9 @@ module Mato
       def format(lexer, source)
         tokens = lexer.lex(source)
         formatter.format(tokens)
+      rescue => ex
+        @on_rouge_error.call(ex)
+        raise RougeError.new
       end
     end
   end

--- a/mato.gemspec
+++ b/mato.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3"
+  spec.required_ruby_version = ">= 2.4"
 
   spec.add_runtime_dependency "commonmarker", ">= 0.18.1"
   spec.add_runtime_dependency "nokogiri", ">= 1.6"

--- a/test/html_filters/syntax_higlight_test.rb
+++ b/test/html_filters/syntax_higlight_test.rb
@@ -123,4 +123,32 @@ class SyntaxHighlightTest < FilterTest
       </div>
     HTML
   end
+
+  def test_call_with_rouge_error
+    markdown = <<~'MD'
+      ```ruby
+      puts "hello"
+      ```
+    MD
+
+    any_instance_of(Rouge::Lexers::Ruby) do |klass|
+      stub(klass).lex { raise "Error!" }
+    end
+
+
+    begin
+      stderr = StringIO.new
+      $stderr = stderr
+      got = highlight(markdown)
+    ensure
+      $stderr = STDERR
+    end
+
+    assert_html_eq(got, <<~'HTML')
+      <div class="code-frame"><pre class="highlight"><code data-lang="plaintext">puts "hello"
+      </code></pre></div>
+    HTML
+
+    assert_equal "Error!\n", stderr.string
+  end
 end

--- a/test/html_filters/syntax_higlight_test.rb
+++ b/test/html_filters/syntax_higlight_test.rb
@@ -135,7 +135,6 @@ class SyntaxHighlightTest < FilterTest
       stub(klass).lex { raise "Error!" }
     end
 
-
     begin
       stderr = StringIO.new
       $stderr = stderr

--- a/test/mato_converter_test.rb
+++ b/test/mato_converter_test.rb
@@ -8,7 +8,7 @@ class MatoConverterTest < MyTest
     end
   end
 
-  def patterns # rubocop:disable Metrics/MethodLength
+  def patterns
     [
       ['#Hello, world!', '# Hello, world!'],
       ['##Hello, world!', '## Hello, world!'],

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'mato'
 
 require 'minitest/autorun'
 require 'minitest/power_assert'
+require 'rr'
 
 class MyTest < MiniTest::Test
   include Minitest::PowerAssert::Assertions


### PR DESCRIPTION
This pull request will suppress Rouge's error and display code block as plain text in SyntaxHighlight filter.


# Problem


Sometimes Rouge raises an error due to Rouge's bug while highlighting. e.g.) https://github.com/rouge-ruby/rouge/pull/1406

The error has a large impact on our service, Kibela.
Because the error conceals the whole of the note even if everything else works well.


# Solution

Rescue Rouge's error, and use PlainText lexer instead.


By this change, the filter will use PlainText lexer instead of the appropriate language lexer if it raises an error.
PlainText lexer highlights nothing, but we can expect it raises an error very rarely.

So the user can see the note content even if Rouge raises an error.

