### PR TITLE
Convert task list even if the text is empty

### DIFF
--- a/lib/mato/html_filters/task_list.rb
+++ b/lib/mato/html_filters/task_list.rb
@@ -3,15 +3,18 @@
 module Mato
   module HtmlFilters
     class TaskList
-      CHECKED_MARK = "[x] "
-      UNCHECKED_MARK = "[ ] "
+      CHECKED_MARK = /\A\[x\] /
+      UNCHECKED_MARK = /\A\[ \] /
+      CHECKED_MARK_FOR_EMPTY_TASK_LIST = /\A\[x\] ?/
+      UNCHECKED_MARK_FOR_EMPTY_TASK_LIST = /\A\[ \] ?/
 
       DEFAULT_TASK_LIST_CLASS = "task-list-item"
       DEFAULT_CHECKBOX_CLASS = "task-list-item-checkbox"
 
-      def initialize(task_list_class: DEFAULT_TASK_LIST_CLASS, checkbox_class: DEFAULT_CHECKBOX_CLASS)
+      def initialize(task_list_class: DEFAULT_TASK_LIST_CLASS, checkbox_class: DEFAULT_CHECKBOX_CLASS, convert_empty_task_list: false)
         @task_list_class = task_list_class
         @checkbox_class = checkbox_class
+        @convert_empty_task_list = convert_empty_task_list
       end
 
       # @param [Nokogiri::HTML::DocumentFragment] doc
@@ -37,18 +40,34 @@ module Mato
       end
 
       def has_checked_mark?(text_node)
-        text_node&.content&.start_with?(CHECKED_MARK)
+        text_node&.content&.match?(checked_mark)
       end
 
       def has_unchecked_mark?(text_node)
-        text_node&.content&.start_with?(UNCHECKED_MARK)
+        text_node&.content&.match?(unchecked_mark)
       end
 
       def trim_mark(content, checked)
         if checked
-          content.sub(CHECKED_MARK, '')
+          content.sub(checked_mark, '')
         else
-          content.sub(UNCHECKED_MARK, '')
+          content.sub(unchecked_mark, '')
+        end
+      end
+
+      def checked_mark
+        if @convert_empty_task_list
+          CHECKED_MARK_FOR_EMPTY_TASK_LIST
+        else
+          CHECKED_MARK
+        end
+      end
+
+      def unchecked_mark
+        if @convert_empty_task_list
+          UNCHECKED_MARK_FOR_EMPTY_TASK_LIST
+        else
+          UNCHECKED_MARK
         end
       end
 

--- a/test/html_filters/task_list_test.rb
+++ b/test/html_filters/task_list_test.rb
@@ -8,7 +8,7 @@ class TaskListTest < FilterTest
     Mato::HtmlFilters::TaskList.new
   end
 
-  def test_simle
+  def test_simple
     input = <<~'MARKDOWN'
       * [ ] foo
       * [x] bar

--- a/test/html_filters/task_list_test.rb
+++ b/test/html_filters/task_list_test.rb
@@ -27,4 +27,26 @@ class TaskListTest < FilterTest
 
     assert_html_eq(mato.process(input).render_html, output)
   end
+
+  def test_empty_task_list
+    # NOTE: The following markdown has trailing spaces on purpose.
+    #       Do NOT remove them!
+    input = <<~'MARKDOWN'
+      * [ ]
+      * [x]
+      * [ ] 
+      * [x] 
+    MARKDOWN
+
+    output = <<~'HTML'
+      <ul>
+      <li>[ ]</li>
+      <li>[x]</li>
+      <li>[ ]</li>
+      <li>[x]</li>
+      </ul>
+    HTML
+
+    assert_html_eq(mato.process(input).render_html, output)
+  end
 end

--- a/test/html_filters/task_list_test.rb
+++ b/test/html_filters/task_list_test.rb
@@ -3,7 +3,6 @@
 require_relative '../test_helper'
 
 class TaskListTest < FilterTest
-
   def subject
     Mato::HtmlFilters::TaskList.new
   end
@@ -44,6 +43,58 @@ class TaskListTest < FilterTest
       <li>[x]</li>
       <li>[ ]</li>
       <li>[x]</li>
+      </ul>
+    HTML
+
+    assert_html_eq(mato.process(input).render_html, output)
+  end
+end
+
+class TaskListEnableConvertEmptyTaskListOptionTest < FilterTest
+  def subject
+    Mato::HtmlFilters::TaskList.new(convert_empty_task_list: true)
+  end
+
+  def test_simple
+    input = <<~'MARKDOWN'
+      * [ ] foo
+      * [x] bar
+      * baz
+    MARKDOWN
+
+    output = <<~'HTML'
+      <ul>
+      <li class="task-list-item">
+      <input type="checkbox" class="task-list-item-checkbox" disabled>foo</li>
+      <li class="task-list-item">
+      <input type="checkbox" class="task-list-item-checkbox" disabled checked>bar</li>
+      <li>baz</li>
+      </ul>
+    HTML
+
+    assert_html_eq(mato.process(input).render_html, output)
+  end
+
+  def test_empty_task_list
+    # NOTE: The following markdown has trailing spaces on purpose.
+    #       Do NOT remove them!
+    input = <<~'MARKDOWN'
+      * [ ]
+      * [x]
+      * [ ] 
+      * [x] 
+    MARKDOWN
+
+    output = <<~'HTML'
+      <ul>
+      <li class="task-list-item">
+      <input type="checkbox" class="task-list-item-checkbox" disabled></li>
+      <li class="task-list-item">
+      <input type="checkbox" class="task-list-item-checkbox" disabled checked></li>
+      <li class="task-list-item">
+      <input type="checkbox" class="task-list-item-checkbox" disabled></li>
+      <li class="task-list-item">
+      <input type="checkbox" class="task-list-item-checkbox" disabled checked></li>
       </ul>
     HTML
 


### PR DESCRIPTION
# What is this pull request

It adds an ability to convert a task list even if the inner text is empty.

For example, previously the following markdown was converted to a list (not "task" list).

```markdown
* [ ]
```

But we will be able to convert it to a task list with `convert_empty_task_list` option.



The option is false by default. It means it doesn't change the current behavior.
It can avoid the breaking change, and the default behavior is the same as GFM.
So I think this feature should be optional and disabled by default.









# Background


See this article (bit journey internal) 
https://bitjourney.kibe.la/notes/7846