### PR TITLE
Allow loose task list

### DIFF
--- a/lib/mato/html_filters/task_list.rb
+++ b/lib/mato/html_filters/task_list.rb
@@ -26,7 +26,7 @@ module Mato
 
       # @param [Nokogiri::XML::Node] li
       def weave(li)
-        text_node = li.xpath('.//text()').first
+        text_node = li.xpath('./p[1]/text()').first || li.xpath('.//text()').first
         checked = has_checked_mark?(text_node)
         unchecked = has_unchecked_mark?(text_node)
 

--- a/test/html_filters/task_list_test.rb
+++ b/test/html_filters/task_list_test.rb
@@ -48,6 +48,32 @@ class TaskListTest < FilterTest
 
     assert_html_eq(mato.process(input).render_html, output)
   end
+
+  def test_loose
+    input = <<~'MARKDOWN'
+      * [ ] foo
+
+      * [x] bar
+
+      * baz
+    MARKDOWN
+
+    output = <<~'HTML'
+      <ul>
+      <li class="task-list-item">
+      <p><input type="checkbox" class="task-list-item-checkbox" disabled>foo</p>
+      </li>
+      <li class="task-list-item">
+      <p><input type="checkbox" class="task-list-item-checkbox" disabled checked>bar</p>
+      </li>
+      <li>
+      <p>baz</p>
+      </li>
+      </ul>
+    HTML
+
+    assert_html_eq(mato.process(input).render_html, output)
+  end
 end
 
 class TaskListEnableConvertEmptyTaskListOptionTest < FilterTest
@@ -95,6 +121,32 @@ class TaskListEnableConvertEmptyTaskListOptionTest < FilterTest
       <input type="checkbox" class="task-list-item-checkbox" disabled></li>
       <li class="task-list-item">
       <input type="checkbox" class="task-list-item-checkbox" disabled checked></li>
+      </ul>
+    HTML
+
+    assert_html_eq(mato.process(input).render_html, output)
+  end
+
+  def test_loose
+    input = <<~'MARKDOWN'
+      * [ ] foo
+
+      * [x] bar
+
+      * baz
+    MARKDOWN
+
+    output = <<~'HTML'
+      <ul>
+      <li class="task-list-item">
+      <p><input type="checkbox" class="task-list-item-checkbox" disabled>foo</p>
+      </li>
+      <li class="task-list-item">
+      <p><input type="checkbox" class="task-list-item-checkbox" disabled checked>bar</p>
+      </li>
+      <li>
+      <p>baz</p>
+      </li>
       </ul>
     HTML
 


### PR DESCRIPTION
This pull request allows loose style task list.


# Problem


Currently, Mato doesn't convert `[ ]` to a task list if the list contains blank line(s) between list items.
For example, It should include two checkboxes, but there're not converted.



```markdown
* [ ] foo

* [ ] bar
```


Because Mato is not aware of "loose" list.


# What is "loose"?

spec: https://spec.commonmark.org/0.29/#loose

> A list is loose if any of its constituent list items are separated by blank lines, or if any of its constituent list items directly contain two block-level elements with a blank line between them. Otherwise a list is tight. (The difference in HTML output is that paragraphs in a loose list are wrapped in `<p>` tags, while paragraphs in a tight list are not.)


A loose list has a `<p>` tag in `<li>`, but Mato didn't treat the `<p>` tag. So it did nothing for loose task lists.


# Solution


Handle `<p>` tag in list item.


# Screenshots


## before

![200714184444](https://user-images.githubusercontent.com/4361134/87411050-1d2dda80-c602-11ea-9a07-fd8e44faa218.png)



## after

![200714184335](https://user-images.githubusercontent.com/4361134/87411048-1c954400-c602-11ea-9a18-229afd7749e7.png)


# Ticket

https://trello.com/c/yWWEBmpr/4923
