### PR TITLE
CI against Ruby 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: ruby
 rvm:
-  - 2.4
-  - 2.5
-  - 2.6
   - 2.7
+  - 3.0
   - ruby-head
 
 matrix:


### PR DESCRIPTION
This pull request enables CI with Ruby 3.0.

It also drops the CI matrix for Ruby 2.6 and lower because we no longer use them.