### PR TITLE
Fix error on mention link with Nokogiri v1.11.0+

### DIFF
--- a/lib/mato/html_filters/mention_link.rb
+++ b/lib/mato/html_filters/mention_link.rb
@@ -53,6 +53,11 @@ module Mato
           candidates.each do |candidate_fragment|
             candidate_fragment.css('span.mention-candidate').each do |node|
               next unless node.child
+              # If link_builder calls Node#replace for a node,
+              # the node's parent becames nil.
+              # Node#replace doesn't accept node that doesn't have parent since Nokogiri v1.11.0,
+              # so we need to skip it.
+              next unless node.parent
 
               node.replace(node.child.content)
             end


### PR DESCRIPTION
This pull request fixes an error on a mention link with Nokogiri v1.11.0+.


# Problem

With Nokogiri v1.11.0, the MentionLInk filter raises an error.
We can confirm the error with the test.

```console

$ bundle exec rake
Run options: --seed 25805

# Running:

..............EE...EE.E...........................

Finished in 0.315472s, 158.4926 runs/s, 120.4544 assertions/s.

  1) Error:
MentionLinkTest#test_mention_filder_for_include_escaped_span_class:
RuntimeError: Cannot replace a node with no parent
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node.rb:270:in `replace'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:57:in `block (2 levels) in call'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:54:in `block in call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:39:in `block in process'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/test_helper.rb:44:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/html_filters/mention_link_test.rb:61:in `test_mention_filder_for_include_escaped_span_class'

  2) Error:
MentionLinkTest#test_mention_filter_for_multiple_valid_accounts:
RuntimeError: Cannot replace a node with no parent
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node.rb:270:in `replace'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:57:in `block (2 levels) in call'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:54:in `block in call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:39:in `block in process'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/test_helper.rb:44:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/html_filters/mention_link_test.rb:35:in `test_mention_filter_for_multiple_valid_accounts'

  3) Error:
MentionLinkTest#test_mention_filter_for_multiple_valid_and_invalid_accounts:
RuntimeError: Cannot replace a node with no parent
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node.rb:270:in `replace'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:57:in `block (2 levels) in call'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:54:in `block in call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:39:in `block in process'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/test_helper.rb:44:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/html_filters/mention_link_test.rb:40:in `test_mention_filter_for_multiple_valid_and_invalid_accounts'

  4) Error:
MentionLinkTest#test_mention_filter_for_valid:
RuntimeError: Cannot replace a node with no parent
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node.rb:270:in `replace'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:57:in `block (2 levels) in call'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:54:in `block in call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:39:in `block in process'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/test_helper.rb:44:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/html_filters/mention_link_test.rb:31:in `test_mention_filter_for_valid'

  5) Error:
MentionLinkTest#test_mention_filder_for_include_escaped_span_class_with_mention_candidate_class:
RuntimeError: Cannot replace a node with no parent
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node.rb:270:in `replace'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:57:in `block (2 levels) in call'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:239:in `block in each'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `upto'
    /home/pocke/.rbenv/versions/3.0.0/lib/ruby/gems/3.0.0/gems/nokogiri-1.11.1-x86_64-linux/lib/nokogiri/xml/node_set.rb:238:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:54:in `block in call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/html_filters/mention_link.rb:53:in `call'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:39:in `block in process'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `each'
    /home/pocke/ghq/github.com/bitjourney/mato/lib/mato/processor.rb:37:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/test_helper.rb:44:in `process'
    /home/pocke/ghq/github.com/bitjourney/mato/test/html_filters/mention_link_test.rb:66:in `test_mention_filder_for_include_escaped_span_class_with_mention_candidate_class'

50 runs, 38 assertions, 0 failures, 5 errors, 0 skips
```



# Cause

We can find the cause from the release note of nokogiri v1.11.0.
https://github.com/sparklemotion/nokogiri/releases/tag/v1.11.0

> The Node methods add_previous_sibling, previous=, before, add_next_sibling, next=, after, replace, and swap now correctly use their parent as the context node for parsing markup. These methods now also raise a RuntimeError if they are called on a node with no parent. [nokogumbo#160]

In short, `Node#replace` raises an error if a node doesn't have a parent.


A node's parent will be nil if `Node#replace` is already called.
For example:

```ruby
require 'nokogiri'

doc = Nokogiri::HTML('foo')
text_node = doc.xpath('.//text()').first
p text_node.parent # => #<Nokogiri::XML::Element:0x50 name="p" children=[#<Nokogiri::XML::Text:0x3c "foo">]>
text_node.replace('bar')
p text_node.parent # => nil
```



In our case, the `link_builder` calls `Node#replace` if it finds correct mentions.
For example: https://github.com/bitjourney/mato/blob/e3ea0bee1358f64fb315e194e711375a17c894c8/test/html_filters/mention_link_test.rb#L24


So we need to skip `Node#replace` to cleanup for correct mentions, but it doesn't.


# Solution


Skip `Node#replace` to cleanup for correct mentions.