### PR TITLE
Fix test_footnotes

### DIFF
--- a/test/mato_test.rb
+++ b/test/mato_test.rb
@@ -54,11 +54,11 @@ class MatoTest < MyTest
 
     assert do
       doc.render_html == <<~'HTML'
-        <p>This is some text.<sup class="footnote-ref"><a href="#fn1" id="fnref1">1</a></sup>. Other text.[^footnote].</p>
-        <section class="footnotes">
+        <p>This is some text.<sup class="footnote-ref"><a href="#fn-1" id="fnref-1" data-footnote-ref>1</a></sup>. Other text.[^footnote].</p>
+        <section class="footnotes" data-footnotes>
         <ol>
-        <li id="fn1">
-        <p>Some <em>bolded</em> footnote definition. <a href="#fnref1" class="footnote-backref">↩</a></p>
+        <li id="fn-1">
+        <p>Some <em>bolded</em> footnote definition. <a href="#fnref-1" class="footnote-backref" data-footnote-backref data-footnote-backref-idx="1" aria-label="Back to reference 1">↩</a></p>
         </li>
         </ol>
         </section>


### PR DESCRIPTION
# Problem

Execute `budle exec rake test`

```
❯ bundle exec rake test
Run options: --seed 61951

# Running:

......................................F...........

Finished in 0.305970s, 163.4147 runs/s, 124.1952 assertions/s.

  1) Failure:
MatoTest#test_footnotes [/Users/shoshimohata/Repos/bitjourney/mato/test/mato_test.rb:55]:
      doc.render_html == <<~'HTML'


50 runs, 38 assertions, 1 failures, 0 errors, 0 skips
rake aborted!
Command failed with status (1)
/Users/shoshimohata/.rbenv/versions/2.7.4/bin/bundle:23:in `load'
/Users/shoshimohata/.rbenv/versions/2.7.4/bin/bundle:23:in `<main>'
Tasks: TOP => test
(See full trace by running task with --trace)

```

Fail test_footnotes

# Solution

Match what is output by doc.render_html .
Maybe test failed due to commonmaker update.

https://github.com/bitjourney/mato/blob/28d4655f7674ef63bb0437526f7efc7377014bd1/mato.gemspec#L30
