### PR TITLE
Correspond to commonmarker v1

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -16,7 +16,6 @@ jobs:
     - name: Use ruby
       uses: ruby/setup-ruby@v1
       with:
-        bundler-cache: true
         ruby-version: '3.1'
 
     - name: rubocop

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -17,7 +17,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-        ruby-version: '3.0'
+        ruby-version: '3.1'
 
     - name: rubocop
       uses: reviewdog/action-rubocop@v2

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Use ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ruby_test.yml
+++ b/.github/workflows/ruby_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1']
+        ruby-version: ["3.1", "3.2", "3.3"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.1
   DisplayCopNames: true
   Exclude:
     - bin/**/*

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mato.process("Hello!").render_html # "<p>HELLO!</p>\n"
 
 ### Markdown Filters
 
-A markdown filter is a callable instance that takes a ``CommonMarker::Node`
+A markdown filter is a callable instance that takes a ``Markly::Node`
 and mutate it in the method. The return value is ignored.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ mato.process("Hello!").render_html # "<p>HELLO!</p>\n"
 
 ### Markdown Filters
 
-A markdown filter is a callable instance that takes a ``Markly::Node`
+A markdown filter is a callable instance that takes a ``Commonmarker::Node`
 and mutate it in the method. The return value is ignored.
 
 For example:

--- a/lib/mato/config.rb
+++ b/lib/mato/config.rb
@@ -3,34 +3,24 @@
 require_relative('./document')
 
 require 'nokogiri'
-require 'markly'
 
 module Mato
   class Config
-    # https://github.com/gjtorikian/commonmarker#parse-options
-    DEFAULT_MARKDOWN_PARSE_OPTIONS = [
-      Markly::DEFAULT,
-      Markly::VALIDATE_UTF8,
-      Markly::FOOTNOTES,
-      Markly::UNSAFE,
-    ].freeze
-
-    # https://github.com/gjtorikian/commonmarker#render-options
-    DEFAULT_MARKDOWN_RENDER_OPTIONS = [
-      :DEFAULT,
-      :HARDBREAKS, # convert "\n" as <br/>
-      :TABLE_PREFER_STYLE_ATTRIBUTES,
-      :UNSAFE,
-      # :SOURCEPOS, // TODO: enable it after assertions are supported
-    ].freeze
-
-    # https://github.com/github/cmark/tree/master/extensions
-    DEFAULT_MARKDOWN_EXTENSIONS = %i[
-      table
-      strikethrough
-      autolink
-      tagfilter
-    ].freeze
+    DEFAULT_MARKDOWN_OPTIONS = {
+      render: {
+        hardbreaks: true,
+        unsafe: true,
+      },
+      extension: {
+        table: true,
+        strikethrough: true,
+        autolink: true,
+        tagfilter: true,
+        tasklist: false,
+        shortcodes: false,
+        footnotes: true,
+      },
+    }.freeze
 
     # @return [Array<Proc>]
     attr_accessor :text_filters
@@ -41,7 +31,7 @@ module Mato
     # @return [Array<Proc>]
     attr_accessor :html_filters
 
-    # @return [Class<Markly]
+    # @return [Class<Commonmarker]
     attr_accessor :markdown_parser
 
     # @return [Cass<Nokogiri::HTML4::DocumentFragment>]
@@ -50,28 +40,20 @@ module Mato
     # @return [Class<Mato::Document>]
     attr_accessor :document_factory
 
-    # @return [Array<Symbol>] Markly's parse extensions
-    attr_accessor :markdown_extensions
-
-    # @return [Array<Class>] Markly's pars options
-    attr_accessor :markdown_parse_options
-
-    # @return [Array<Symbol>] Commonmarker's HTML rendering options
-    attr_accessor :markdown_render_options
+    # @return [Hash] Commonmarker's options
+    attr_accessor :markdown_options
 
     def initialize
       @text_filters = []
       @markdown_filters = []
       @html_filters = []
 
-      @markdown_parser = Markly
+      @markdown_parser = Commonmarker
       @html_parser = Nokogiri::HTML4::DocumentFragment
 
       @document_factory = Document
 
-      @markdown_extensions = DEFAULT_MARKDOWN_EXTENSIONS
-      @markdown_parse_options = DEFAULT_MARKDOWN_PARSE_OPTIONS
-      @markdown_render_options = DEFAULT_MARKDOWN_RENDER_OPTIONS
+      @markdown_options = DEFAULT_MARKDOWN_OPTIONS
     end
 
     # @param [Proc] block

--- a/lib/mato/config.rb
+++ b/lib/mato/config.rb
@@ -3,14 +3,16 @@
 require_relative('./document')
 
 require 'nokogiri'
+require 'markly'
 
 module Mato
   class Config
     # https://github.com/gjtorikian/commonmarker#parse-options
-    DEFAULT_MARKDOWN_PARSE_OPTIONS = %i[
-      DEFAULT
-      VALIDATE_UTF8
-      FOOTNOTES
+    DEFAULT_MARKDOWN_PARSE_OPTIONS = [
+      Markly::DEFAULT,
+      Markly::VALIDATE_UTF8,
+      Markly::FOOTNOTES,
+      Markly::UNSAFE,
     ].freeze
 
     # https://github.com/gjtorikian/commonmarker#render-options
@@ -39,7 +41,7 @@ module Mato
     # @return [Array<Proc>]
     attr_accessor :html_filters
 
-    # @return [Class<CommonMarker]
+    # @return [Class<Markly]
     attr_accessor :markdown_parser
 
     # @return [Cass<Nokogiri::HTML4::DocumentFragment>]
@@ -48,13 +50,13 @@ module Mato
     # @return [Class<Mato::Document>]
     attr_accessor :document_factory
 
-    # @return [Array<Symbol>] CommonMarker's parse extensions
+    # @return [Array<Symbol>] Markly's parse extensions
     attr_accessor :markdown_extensions
 
-    # @return [Array<Symbol>] CommonMarker's pars options
+    # @return [Array<Class>] Markly's pars options
     attr_accessor :markdown_parse_options
 
-    # @return [Array<Symbol>] CommonMarker's HTML rendering options
+    # @return [Array<Symbol>] Commonmarker's HTML rendering options
     attr_accessor :markdown_render_options
 
     def initialize
@@ -62,7 +64,7 @@ module Mato
       @markdown_filters = []
       @html_filters = []
 
-      @markdown_parser = CommonMarker
+      @markdown_parser = Markly
       @html_parser = Nokogiri::HTML4::DocumentFragment
 
       @document_factory = Document

--- a/lib/mato/converter.rb
+++ b/lib/mato/converter.rb
@@ -29,7 +29,7 @@ module Mato
     end
 
     def run
-      # @type [Markly::Node]
+      # @type [Commonmarker::Node]
       document = processor.parse_markdown(content)
 
       convert_headings!(document)

--- a/lib/mato/converter.rb
+++ b/lib/mato/converter.rb
@@ -29,7 +29,7 @@ module Mato
     end
 
     def run
-      # @type [CommonMarker::Node]
+      # @type [Markly::Node]
       document = processor.parse_markdown(content)
 
       convert_headings!(document)
@@ -45,14 +45,14 @@ module Mato
     def convert_headings!(document)
       document.walk.select do |node|
         node.type == :text &&
-          node.sourcepos[:start_column] == 1 &&
+          node.source_position[:start_column] == 1 &&
           node.parent.type == :paragraph &&
           node.parent.parent.type == :document
       end.reverse_each do |node|
         replacement = node.string_content.gsub(/\A(#+)(?=\S)/, '\1 ')
 
         if node.string_content != replacement
-          pos = node.sourcepos
+          pos = node.source_position
           content_lines[pos[:start_line] - 1][(pos[:start_column] - 1)...pos[:end_column]] = replacement
         end
       end

--- a/lib/mato/processor.rb
+++ b/lib/mato/processor.rb
@@ -12,6 +12,9 @@ module Mato
 
     def initialize(config)
       @config = config
+      config.markdown_parse_options.each do |options|
+        @flags = @flags ? @flags | options : options
+      end
     end
 
     # @param [String] input
@@ -43,15 +46,15 @@ module Mato
     end
 
     # @param [String] text
-    # @return [CommonMarker::Node]
+    # @return [Markly::Node]
     def parse_markdown(text)
-      config.markdown_parser.render_doc(text, config.markdown_parse_options, config.markdown_extensions)
+      config.markdown_parser.parse(text, flags: @flags, extensions: config.markdown_extensions)
     end
 
-    # @param [CommonMarker::Node] markdown_node
+    # @param [Markly::Node] markdown_node
     # @return [String]
     def render_to_html(markdown_node)
-      markdown_node.to_html(config.markdown_render_options)
+      markdown_node.to_html(flags: @flags)
     end
 
     # @param [String] html

--- a/lib/mato/processor.rb
+++ b/lib/mato/processor.rb
@@ -12,9 +12,6 @@ module Mato
 
     def initialize(config)
       @config = config
-      config.markdown_parse_options.each do |options|
-        @flags = @flags ? @flags | options : options
-      end
     end
 
     # @param [String] input
@@ -46,15 +43,15 @@ module Mato
     end
 
     # @param [String] text
-    # @return [Markly::Node]
+    # @return [Commonmarker::Node]
     def parse_markdown(text)
-      config.markdown_parser.parse(text, flags: @flags, extensions: config.markdown_extensions)
+      config.markdown_parser.parse(text, options: config.markdown_options)
     end
 
-    # @param [Markly::Node] markdown_node
+    # @param [Commonmarker::Node] markdown_node
     # @return [String]
     def render_to_html(markdown_node)
-      markdown_node.to_html(flags: @flags)
+      markdown_node.to_html(options: config.markdown_options)
     end
 
     # @param [String] html

--- a/mato.gemspec
+++ b/mato.gemspec
@@ -27,7 +27,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.7"
 
-  spec.add_runtime_dependency "commonmarker", ">= 0.18.1"
+  spec.add_runtime_dependency "commonmarker", "~> 1.0"
+  spec.add_runtime_dependency "markly", "~> 0.9"
   spec.add_runtime_dependency "nokogiri", ">= 1.12"
   spec.add_runtime_dependency "rouge", ">= 3.0.0"
 end

--- a/mato.gemspec
+++ b/mato.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = "~> 3.1"
 
   spec.add_runtime_dependency "commonmarker", "~> 1.0"
-  spec.add_runtime_dependency "markly", "~> 0.9"
   spec.add_runtime_dependency "nokogiri", ">= 1.12"
   spec.add_runtime_dependency "rouge", ">= 3.0.0"
 end

--- a/mato.gemspec
+++ b/mato.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.7"
+  spec.required_ruby_version = "~> 3.1"
 
   spec.add_runtime_dependency "commonmarker", "~> 1.0"
   spec.add_runtime_dependency "markly", "~> 0.9"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'minitest/power_assert'
 require 'active_support'
 require 'rr'
 
-class MyTest < MiniTest::Test
+class MyTest < Minitest::Test
   include Minitest::PowerAssert::Assertions
 
   def assert_html_eq(actual, expected)


### PR DESCRIPTION
resolves #33 

- Bump up Ruby version to ~> 3.1 ([commonmarker v1 requires](https://github.com/gjtorikian/commonmarker/blob/main/commonmarker.gemspec))
- Bump up [commonmarker](https://github.com/gjtorikian/commonmarker) to ~>1.0
  - Major version up of commonmarker is agressive!
- (Correspond to recent Minitest)